### PR TITLE
focus status in 3rd gen cameras

### DIFF
--- a/Rocc/Manufacturer Implementations/Sony/API/CameraClient.swift
+++ b/Rocc/Manufacturer Implementations/Sony/API/CameraClient.swift
@@ -81,9 +81,9 @@ fileprivate extension FocusStatus {
             self = .notFocussing
         case "Failed":
             self = .failed
-        case "Focusing":
+        case let str where str.starts(with: "Focusing"):
             self = .focusing
-        case "Focused":
+        case let str where str.starts(with: "Focused"):
             self = .focused
         default:
             return nil


### PR DESCRIPTION
Hi Simon, thanks for a great library!

This PR fixes the way Rocc handles focus events in 3rd gen cameras. When A7 III is set to AF-C, it'll send "Focused with Subject Tracking" values.