### PR TITLE
fix type definitions for Continuous Capture functions

### DIFF
--- a/Rocc/Camera Functions/Capture.swift
+++ b/Rocc/Camera Functions/Capture.swift
@@ -121,10 +121,10 @@ public struct ContinuousCapture: CameraFunction {
         public typealias ReturnType = ContinuousShootingMode
         
         /// Sets the continous shooting mode
-        public static let set = ContinuousCapture(function: .setContinuousShootingMode)
+        public static let set = Mode(function: .setContinuousShootingMode)
         
         /// Returns the current continuous shooting mode
-        public static let get = ContinuousCapture(function: .getContinuousShootingMode)
+        public static let get = Mode(function: .getContinuousShootingMode)
     }
     
     /// Functions for interacting with the continuous shooting speed
@@ -137,10 +137,10 @@ public struct ContinuousCapture: CameraFunction {
         public typealias ReturnType = ContinuousShootingSpeed
         
         /// Sets the continuous shooting speed
-        public static let set = ContinuousCapture(function: .setContinuousShootingSpeed)
+        public static let set = Speed(function: .setContinuousShootingSpeed)
         
         /// Returns the current continuous shooting speed
-        public static let get = ContinuousCapture(function: .getContinuousShootingSpeed)
+        public static let get = Speed(function: .getContinuousShootingSpeed)
     }
 }
 


### PR DESCRIPTION
Before this fix, `performFunction` would incorrectly infer types for callback argument.

```
performFunction(ContinuousCapture.Mode.set, .single) { error, result in
}
```

would throw "Cannot cast (_, _) -> () into (Error?, _.ReturnType?) -> Void" error.