### PR TITLE
add public constructors

### DIFF
--- a/Sources/Camera Functions/Aperture.swift
+++ b/Sources/Camera Functions/Aperture.swift
@@ -14,8 +14,12 @@ public struct Aperture: CameraFunction {
     public struct Value {
                         
         public let value: Double
-        
         internal let decimalSeperator: String?
+
+        public init(value: Double, decimalSeperator: String? = nil) {
+            self.value = value
+            self.decimalSeperator = decimalSeperator
+        }
     }
     
     public var function: _CameraFunction

--- a/Sources/Camera Functions/Exposure.swift
+++ b/Sources/Camera Functions/Exposure.swift
@@ -119,6 +119,10 @@ public struct Exposure {
         public struct Value: Equatable {
             /// The double value the given exposure compensation represents
             public let value: Double
+
+            public init(value: Double) {
+                self.value = value
+            }
         }
         
         public var function: _CameraFunction

--- a/Sources/Helpers/Strings/ApertureFormatter.swift
+++ b/Sources/Helpers/Strings/ApertureFormatter.swift
@@ -9,7 +9,9 @@
 import Foundation
 
 public class ApertureFormatter {
-    
+    public init() {
+    }
+
     public func string(for obj: Aperture.Value?) -> String? {
         
         guard let aperture = obj else {


### PR DESCRIPTION
Tiny change to allow users to manually create some of your objects.

Context:
* I set arbitrary Aperture and Exposure values on SimulatedCamera to generate App Store screenshots
* ApertureFormatter to display apertures in the UI