### PR TITLE
expose Sony's API version

### DIFF
--- a/Sources/Camera.swift
+++ b/Sources/Camera.swift
@@ -119,7 +119,10 @@ public protocol Camera: class {
     
     /// The latest version of the remote app runnable on the camera.
     var latestRemoteAppVersion: String? { get }
-    
+
+    /// The latest version of the getEvent API
+    var eventVersion: String? { get }
+
     /// The lens connected to the camera.
     var lensModelName: String? { get }
     

--- a/Sources/Helpers/SimulatedCamera.swift
+++ b/Sources/Helpers/SimulatedCamera.swift
@@ -137,7 +137,9 @@ public final class DummyCamera: Camera {
     public var lensModelName: String?
     
     public var apiVersion: String?
-    
+
+    public var eventVersion: String?
+
     public var model: String?
     
     public var identifier: String = "dummy"

--- a/Sources/Manufacturer Implementations/Sony/PTP IP Camera/SonyPTPIPCamera.swift
+++ b/Sources/Manufacturer Implementations/Sony/PTP IP Camera/SonyPTPIPCamera.swift
@@ -34,6 +34,10 @@ internal final class SonyPTPIPDevice: SonyCamera {
     var remoteAppVersion: String? = nil
     
     var latestRemoteAppVersion: String? = nil
+
+    var eventVersion: String? {
+        return "2.0"
+    }
     
     var lensModelName: String? = nil
     

--- a/Sources/Manufacturer Implementations/Sony/Remote Control API Camera/SonyAPICamera.swift
+++ b/Sources/Manufacturer Implementations/Sony/Remote Control API Camera/SonyAPICamera.swift
@@ -140,6 +140,8 @@ internal final class SonyAPICameraDevice: SonyCamera {
     public var latestRemoteAppVersion: String? {
         return modelEnum?.latestRemoteAppVersion ?? "4.30"
     }
+
+    public var eventVersion: String?
     
     public var lensModelName: String?
     
@@ -245,6 +247,8 @@ extension SonyAPICameraDevice: Camera {
                 if case let .failure(error) = result, (error as NSError).code != 404 {
                     callback(Result.failure(error))
                     return
+                } else if case let .success(versions) = result {
+                    self.eventVersion = versions.map { Double($0) }.compactMap { $0 }.max().map { String($0) }
                 }
                     
                 guard let avClient = self.apiClient.avContent else {

--- a/Sources/Manufacturer Implementations/Sony/Transfer Device/SonyTransferDevice.swift
+++ b/Sources/Manufacturer Implementations/Sony/Transfer Device/SonyTransferDevice.swift
@@ -37,6 +37,8 @@ internal final class SonyTransferDevice {
     var latestRemoteAppVersion: String? {
         return "4.31"
     }
+
+    var eventVersion: String?
     
     var identifier: String
     


### PR DESCRIPTION
I use the API version to determine if certain UI elements are visible (i.e. ask user to double-check their file format when dealing with Smart Remote Control, hide status bar [battery, sd card, AF etc] when on a7III and similar etc)

This might not be the best way of doing this but curious about your thoughts.